### PR TITLE
"envprovements"

### DIFF
--- a/conqace.py
+++ b/conqace.py
@@ -17,13 +17,37 @@ parser.add_argument("--snap", "-s", help="updates snaps as well.", action="store
 parser.add_argument("--no-notify", "-N", help="skips the phone notification.", action="store_true")
 args = parser.parse_args()
 
-load_dotenv()
-payload = {
-    "app_key": os.getenv("PUSHED_APP_KEY"),
-    "app_secret": os.getenv('PUSHED_APP_SECRET'),
-    "target_type": "app",
-    "content": "Update Successful."
-}
+
+def first_run():
+    if os.path.exists(".env"):
+        load_dotenv()
+        temppl = {
+            "app_key": os.getenv("PUSHED_APP_KEY"),
+            "app_secret": os.getenv('PUSHED_APP_SECRET'),
+            "target_type": "app",
+            "content": "Update Successful."
+        }
+        return temppl
+    else:
+
+        environfile = open(r".env", "w+")
+        logger.info("No .env file found. Creating new one.")
+        logger.info("Please enter in your Pushed App Key (not the secret)")
+        appkey = input()
+        logger.info("Please enter in your App Secret (not the key)")
+        appsecret = input()
+        logger.info("writing to .env file...")
+        environfile.write(f"PUSHED_APP_KEY={appkey}\nPUSHED_APP_SECRET={appsecret}")
+        logger.info("done.")
+        environfile.close()
+        load_dotenv()
+        temppl = {
+            "app_key": os.getenv("PUSHED_APP_KEY"),
+            "app_secret": os.getenv('PUSHED_APP_SECRET'),
+            "target_type": "app",
+            "content": "Update Successful."
+        }
+        return temppl
 
 
 def snappak():
@@ -98,6 +122,8 @@ def arch_pacman():
     logger.info("complete.")
     logger.info("sending notification.")
     notification()
+
+
 def gentoo_emerge():
     logger.info("Syncing with emaint.")
     time.sleep(2)
@@ -129,4 +155,5 @@ def ubuntu_apt():
     notification()
 
 
+payload = first_run()
 start_update()

--- a/conqace.py
+++ b/conqace.py
@@ -30,7 +30,9 @@ def first_run():
         return temppl
     else:
 
-        environfile = open(r".env", "w+")
+        with open(r".env", "w+") as environfile:
+            logger.info("No .env file found. Creating new one.")
+            logger.info("Please enter in your Pushed App Key (not the secret)")
         logger.info("No .env file found. Creating new one.")
         logger.info("Please enter in your Pushed App Key (not the secret)")
         appkey = input()


### PR DESCRIPTION
making pusher api keys automatically asked for on run.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a feature that automatically prompts the user for Pusher API keys if they are not found in the .env file. It also includes a refactoring to check for the existence of the .env file and create it if necessary.

- **New Features**:
    - Automatically prompts the user for Pusher API keys if they are not found in the .env file.
- **Enhancements**:
    - Refactored the code to check for the existence of the .env file and create it if it does not exist.

<!-- Generated by sourcery-ai[bot]: end summary -->